### PR TITLE
Add Sessions analytics views

### DIFF
--- a/src/layouts/AppShell.vue
+++ b/src/layouts/AppShell.vue
@@ -1,0 +1,128 @@
+<template>
+  <div class="min-h-screen flex bg-gray-50 dark:bg-gray-950 transition-colors duration-300">
+    <!-- Sidebar -->
+    <aside
+      class="w-64 bg-white dark:bg-gray-900/50 border-r border-gray-200 dark:border-gray-800/50 flex flex-col shrink-0 transition-colors duration-300"
+    >
+      <!-- Brand -->
+      <div
+        class="p-5 border-b border-gray-100 dark:border-gray-800/50 flex items-center justify-between"
+      >
+        <div class="flex items-center gap-3">
+          <div
+            class="w-9 h-9 rounded-xl bg-brand-500/10 border border-brand-500/20 flex items-center justify-center"
+          >
+            <svg
+              class="w-5 h-5 text-brand-500 dark:text-brand-400"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              stroke-width="1.5"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M7.5 14.25v2.25m3-4.5v4.5m3-6.75v6.75m3-9v9M6 20.25h12A2.25 2.25 0 0020.25 18V6A2.25 2.25 0 0018 3.75H6A2.25 2.25 0 003.75 6v12A2.25 2.25 0 006 20.25z"
+              />
+            </svg>
+          </div>
+          <div>
+            <h1 class="text-sm font-semibold text-gray-900 dark:text-white">
+              Qulox
+            </h1>
+            <p class="text-xs text-gray-500">Dashboard</p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Nav -->
+      <nav class="flex-1 p-3 space-y-1">
+        <router-link
+          to="/dashboard"
+          class="flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium transition-all duration-150"
+          :class="
+            $route.name === 'Dashboard'
+              ? 'bg-brand-500/10 text-brand-600 dark:text-brand-400 whitespace-nowrap'
+              : 'text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-gray-800/50'
+          "
+        >
+          <svg
+            class="w-5 h-5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            stroke-width="1.5"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z"
+            />
+          </svg>
+          文件管理
+        </router-link>
+        <router-link
+          to="/dashboard/clients"
+          class="flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium transition-all duration-150"
+          :class="
+            $route.name === 'Clients'
+              ? 'bg-brand-500/10 text-brand-600 dark:text-brand-400'
+              : 'text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-gray-800/50'
+          "
+        >
+          <svg
+            class="w-5 h-5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            stroke-width="1.5"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M15 19.128a9.38 9.38 0 002.625.372 9.337 9.337 0 004.121-.952 4.125 4.125 0 00-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 018.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0111.964-3.07M12 6.375a3.375 3.375 0 11-6.75 0 3.375 3.375 0 016.75 0zm8.25 2.25a2.625 2.625 0 11-5.25 0 2.625 2.625 0 015.25 0z"
+            />
+          </svg>
+          客戶管理
+        </router-link>
+        <router-link
+          to="/dashboard/sessions"
+          class="flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium transition-all duration-150"
+          :class="
+            $route.name === 'Sessions'
+              ? 'bg-brand-500/10 text-brand-600 dark:text-brand-400'
+              : 'text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-gray-800/50'
+          "
+        >
+          <svg
+            class="w-5 h-5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            stroke-width="1.5"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M3.75 4.5h16.5M3.75 9.75h16.5m-16.5 5.25h10.5"
+            />
+          </svg>
+          閱讀紀錄
+        </router-link>
+      </nav>
+
+      <!-- User section -->
+      <slot name="user" />
+    </aside>
+
+    <!-- Main content -->
+    <main class="flex-1 overflow-auto">
+      <slot />
+    </main>
+  </div>
+</template>
+
+<script setup>
+// 這個 layout 目前只用在 Sessions/SessionDetail 上，
+// 所以先只負責 sidebar + main slots。
+</script>

--- a/src/pages/DashboardPage.vue
+++ b/src/pages/DashboardPage.vue
@@ -88,6 +88,30 @@
           </svg>
           客戶管理
         </router-link>
+        <router-link
+          to="/dashboard/sessions"
+          class="flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium transition-all duration-150"
+          :class="
+            $route.name === 'Sessions'
+              ? 'bg-brand-500/10 text-brand-600 dark:text-brand-400'
+              : 'text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-gray-800/50'
+          "
+        >
+          <svg
+            class="w-5 h-5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            stroke-width="1.5"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M3.75 4.5h16.5M3.75 9.75h16.5m-16.5 5.25h10.5"
+            />
+          </svg>
+          閱讀紀錄
+        </router-link>
       </nav>
 
       <!-- User section -->

--- a/src/pages/SessionDetailPage.vue
+++ b/src/pages/SessionDetailPage.vue
@@ -1,0 +1,343 @@
+<template>
+  <AppShell>
+    <div class="p-8 max-w-5xl mx-auto">
+      <div class="flex items-center justify-between mb-6">
+        <div>
+          <h2 class="text-lg font-semibold text-gray-900 dark:text-white">
+            閱讀細節
+          </h2>
+          <p class="text-sm text-gray-500">
+            單次閱讀行為的細節：每頁停留時間與關鍵互動。
+          </p>
+        </div>
+        <button
+          type="button"
+          @click="goBack"
+          class="inline-flex items-center gap-1 px-3 py-1.5 text-xs border border-gray-200 dark:border-gray-700 rounded-xl text-gray-600 dark:text-gray-300 hover:bg-gray-100/70 dark:hover:bg-gray-800/70"
+        >
+          <span>←</span>
+          <span>回到 閱讀紀錄</span>
+        </button>
+      </div>
+
+      <div v-if="isLoading" class="flex items-center justify-center py-16">
+        <svg
+          class="w-6 h-6 animate-spin text-brand-500"
+          fill="none"
+          viewBox="0 0 24 24"
+        >
+          <circle
+            class="opacity-25"
+            cx="12"
+            cy="12"
+            r="10"
+            stroke="currentColor"
+            stroke-width="4"
+          />
+          <path
+            class="opacity-75"
+            fill="currentColor"
+            d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+          />
+        </svg>
+      </div>
+
+      <div v-else-if="!session" class="text-sm text-gray-500">
+        找不到這個 session。
+      </div>
+
+      <div v-else class="space-y-6">
+        <!-- Overview card -->
+        <div
+          class="rounded-2xl border border-gray-200 dark:border-gray-800/60 bg-white dark:bg-gray-900/60 p-5 flex flex-col md:flex-row md:items-center md:justify-between gap-4"
+        >
+          <div class="space-y-1">
+            <p class="text-xs text-gray-500">Document</p>
+            <p class="text-sm font-medium text-gray-900 dark:text-white">
+              {{ session.documentId || '—' }}
+            </p>
+            <p class="text-xs text-gray-500">
+              Link: {{ session.linkId || '—' }}
+            </p>
+            <p class="text-xs text-gray-500">
+              Client: {{ session.clientName || '—' }}
+            </p>
+          </div>
+          <div class="flex flex-wrap gap-4 items-center">
+            <div>
+              <p class="text-xs text-gray-500 mb-1">Intent</p>
+              <span
+                class="inline-flex items-center gap-1 px-3 py-1 rounded-full border text-xs font-medium"
+                :class="[
+                  getScoreColor(session.intentScore || 0).bg,
+                  getScoreColor(session.intentScore || 0).text,
+                  getScoreColor(session.intentScore || 0).border,
+                ]"
+              >
+                <span>{{ getScoreLabel(session.intentScore || 0) }}</span>
+                <span>· {{ session.intentScore ?? 0 }}</span>
+              </span>
+            </div>
+            <div>
+              <p class="text-xs text-gray-500 mb-1">總閱讀時間</p>
+              <p class="text-sm font-semibold text-gray-900 dark:text-white">
+                {{ formatDwell(session.totalDwellSecs || 0) }}
+              </p>
+            </div>
+            <div>
+              <p class="text-xs text-gray-500 mb-1">時間</p>
+              <p class="text-xs text-gray-500">
+                {{ formatRange(session.startedAt, session.endedAt) }}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <!-- Per-page dwell chart -->
+        <div
+          class="rounded-2xl border border-gray-200 dark:border-gray-800/60 bg-white dark:bg-gray-900/60 p-5"
+        >
+          <div class="flex items-center justify-between mb-3">
+            <p class="text-sm font-medium text-gray-900 dark:text-white">
+              每頁停留時間
+            </p>
+            <p class="text-xs text-gray-500">
+              橫條越長代表在該頁停留越久。
+            </p>
+          </div>
+          <div v-if="pageEntries.length === 0" class="text-xs text-gray-500">
+            沒有 pageStats 資料。
+          </div>
+          <div v-else class="space-y-2">
+            <div
+              v-for="p in pageEntries"
+              :key="p.page"
+              class="flex items-center gap-3"
+            >
+              <div class="w-10 text-xs text-gray-500 shrink-0">P{{ p.page }}</div>
+              <div
+                class="flex-1 h-4 bg-gray-100 dark:bg-gray-800 rounded-full overflow-hidden"
+              >
+                <div
+                  class="h-full rounded-full bg-brand-500/80"
+                  :style="{ width: p.normalizedWidth + '%' }"
+                ></div>
+              </div>
+              <div class="w-20 text-xs text-gray-500 text-right shrink-0">
+                {{ p.dwellLabel }}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Key behaviors panel -->
+        <div
+          class="rounded-2xl border border-gray-200 dark:border-gray-800/60 bg-white dark:bg-gray-900/60 p-5"
+        >
+          <p class="text-sm font-medium text-gray-900 dark:text-white mb-3">
+            Key Behaviors
+          </p>
+          <div
+            v-if="!session.events || session.events.length === 0"
+            class="text-xs text-gray-500"
+          >
+            沒有記錄到任何互動事件。
+          </div>
+          <div v-else class="space-y-3">
+            <div class="flex flex-wrap gap-2">
+              <span
+                v-if="hasPrintIntent"
+                class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-rose-500/10 text-rose-600 dark:text-rose-400 border border-rose-500/20"
+              >
+                🖨️ 有列印意圖
+              </span>
+              <span
+                v-if="hasCopy"
+                class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-amber-500/10 text-amber-600 dark:text-amber-400 border border-amber-500/20"
+              >
+                📋 有複製文字
+              </span>
+              <span
+                v-if="hasSelectionOnly"
+                class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-sky-500/10 text-sky-600 dark:text-sky-400 border border-sky-500/20"
+              >
+                ✏️ 有選取重點
+              </span>
+              <span
+                v-if="hasLinkClick"
+                class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border border-emerald-500/20"
+              >
+                🔗 點擊文件中的連結
+              </span>
+              <span
+                v-if="hasZoomScrutinize"
+                class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-purple-500/10 text-purple-600 dark:text-purple-400 border border-purple-500/20"
+              >
+                🔍 放大仔細查看內容
+              </span>
+            </div>
+
+            <div
+              class="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs text-gray-500"
+            >
+              <div v-if="copyPages.length">
+                <p class="font-medium text-gray-700 dark:text-gray-200 mb-1">
+                  複製文字的頁面
+                </p>
+                <p>頁碼：P{{ copyPages.join(', P') }}</p>
+              </div>
+              <div v-if="selectionPages.length">
+                <p class="font-medium text-gray-700 dark:text-gray-200 mb-1">
+                  有選取文字的頁面
+                </p>
+                <p>頁碼：P{{ selectionPages.join(', P') }}</p>
+              </div>
+              <div v-if="linkClickPages.length">
+                <p class="font-medium text-gray-700 dark:text-gray-200 mb-1">
+                  點擊連結的頁面
+                </p>
+                <p>頁碼：P{{ linkClickPages.join(', P') }}</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </AppShell>
+</template>
+
+<script setup>
+import { computed, ref, onMounted } from "vue";
+import { useRoute, useRouter } from "vue-router";
+import AppShell from "../layouts/AppShell.vue";
+import { doc, getDoc } from "firebase/firestore";
+import { db } from "../services/firebase.js";
+import { useTrackingSessions } from "../composables/useScores.js";
+
+const route = useRoute();
+const router = useRouter();
+const session = ref(null);
+const isLoading = ref(true);
+
+const { getScoreLabel, getScoreColor } = useTrackingSessions();
+
+const goBack = () => {
+  router.push("/dashboard/sessions");
+};
+
+onMounted(async () => {
+  const id = route.params.id;
+  if (!id) {
+    isLoading.value = false;
+    return;
+  }
+  try {
+    const snap = await getDoc(doc(db, "tracking_sessions", id));
+    if (snap.exists()) {
+      session.value = { id: snap.id, ...snap.data() };
+    }
+  } catch (e) {
+    console.error("Failed to load session", e);
+  } finally {
+    isLoading.value = false;
+  }
+});
+
+const pageEntries = computed(() => {
+  if (!session.value?.pageStats) return [];
+  const entries = Object.entries(session.value.pageStats).map(
+    ([page, data]) => ({
+      page: Number(page),
+      dwellSecs: Math.round((data.totalDwellMs || 0) / 1000),
+    }),
+  );
+  const maxDwell = entries.reduce(
+    (max, p) => (p.dwellSecs > max ? p.dwellSecs : max),
+    0,
+  );
+  return entries
+    .sort((a, b) => a.page - b.page)
+    .map((p) => ({
+      ...p,
+      normalizedWidth: maxDwell
+        ? Math.max((p.dwellSecs / maxDwell) * 100, 4)
+        : 0,
+      dwellLabel:
+        p.dwellSecs < 60
+          ? `${p.dwellSecs}s`
+          : `${Math.floor(p.dwellSecs / 60)}m ${p.dwellSecs % 60}s`,
+    }));
+});
+
+const events = computed(() => session.value?.events || []);
+
+const hasPrintIntent = computed(() =>
+  events.value.some((e) => e.type === "print_intent"),
+);
+const hasCopy = computed(() =>
+  events.value.some((e) => e.type === "text_copy"),
+);
+const hasSelectionOnly = computed(() =>
+  !hasCopy.value && events.value.some((e) => e.type === "text_selection"),
+);
+const hasLinkClick = computed(() =>
+  events.value.some((e) => e.type === "link_click"),
+);
+const hasZoomScrutinize = computed(() =>
+  events.value.some((e) => e.type === "zoom_scrutinize"),
+);
+
+const copyPages = computed(() => {
+  const set = new Set(
+    events.value
+      .filter((e) => e.type === "text_copy" && e.page)
+      .map((e) => e.page),
+  );
+  return Array.from(set).sort((a, b) => a - b);
+});
+
+const selectionPages = computed(() => {
+  const set = new Set(
+    events.value
+      .filter((e) => e.type === "text_selection" && e.page)
+      .map((e) => e.page),
+  );
+  return Array.from(set).sort((a, b) => a - b);
+});
+
+const linkClickPages = computed(() => {
+  const set = new Set(
+    events.value
+      .filter((e) => e.type === "link_click" && e.page)
+      .map((e) => e.page),
+  );
+  return Array.from(set).sort((a, b) => a - b);
+});
+
+const formatDwell = (totalSecs) => {
+  if (!totalSecs || totalSecs <= 0) return "0s";
+  if (totalSecs < 60) return `${totalSecs}s`;
+  if (totalSecs < 3600)
+    return `${Math.floor(totalSecs / 60)}m ${totalSecs % 60}s`;
+  const hrs = Math.floor(totalSecs / 3600);
+  const mins = Math.floor((totalSecs % 3600) / 60);
+  return `${hrs}h ${mins}m`;
+};
+
+const formatRange = (start, end) => {
+  const s = start?.toDate?.() ? start.toDate() : null;
+  const e = end?.toDate?.() ? end.toDate() : null;
+  if (!s && !e) return "—";
+  if (s && e) {
+    return `${s.toLocaleTimeString("zh-TW", {
+      hour: "2-digit",
+      minute: "2-digit",
+    })} - ${e.toLocaleTimeString("zh-TW", {
+      hour: "2-digit",
+      minute: "2-digit",
+    })}`;
+  }
+  const ts = s || e;
+  return ts.toLocaleString("zh-TW");
+};
+</script>

--- a/src/pages/SessionsPage.vue
+++ b/src/pages/SessionsPage.vue
@@ -1,0 +1,299 @@
+<template>
+  <AppShell>
+    <template #user>
+      <!-- 使用 DashboardPage 的 user 區塊邏輯會比較好，但目前先簡化為空 slot -->
+    </template>
+    <div class="p-8">
+      <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+        閱讀紀錄
+      </h2>
+    <p class="text-sm text-gray-500 mb-6">
+      最近的閱讀紀錄，含單次閱讀的 intent score。
+    </p>
+
+    <!-- Filter: document select -->
+    <div
+      v-if="documents.length > 0"
+      class="mb-4 flex items-center justify-between gap-4"
+    >
+      <div class="text-xs text-gray-500">
+        目前篩選：
+        <span class="font-medium text-gray-700 dark:text-gray-200">
+          {{ selectedDocumentId === 'all'
+            ? '全部文件'
+            : (documents.find((d) => d.id === selectedDocumentId)?.name || selectedDocumentId)
+          }}
+        </span>
+      </div>
+      <select
+        v-model="selectedDocumentId"
+        class="text-xs px-2 py-1.5 border border-gray-200 dark:border-gray-700 rounded-lg bg-white dark:bg-gray-900 text-gray-700 dark:text-gray-200"
+      >
+        <option value="all">全部文件</option>
+        <option v-for="doc in documents" :key="doc.id" :value="doc.id">
+          {{ doc.name }}
+        </option>
+      </select>
+    </div>
+
+    <!-- Summary panel: Today HOT/WARM sessions -->
+    <div
+      v-if="!isLoading && filteredSessions.length > 0"
+      class="mb-6 grid grid-cols-1 md:grid-cols-3 gap-4"
+    >
+      <div
+        class="rounded-2xl border border-gray-200 dark:border-gray-800/60 bg-white dark:bg-gray-900/60 px-4 py-3 flex items-center justify-between"
+      >
+        <div>
+          <p class="text-xs text-gray-500">今天的 HOT sessions</p>
+          <p class="text-2xl font-semibold text-gray-900 dark:text-white">
+            {{ todayStats.hotCount }}
+          </p>
+        </div>
+        <span class="text-xl">🔥</span>
+      </div>
+      <div
+        class="rounded-2xl border border-gray-200 dark:border-gray-800/60 bg-white dark:bg-gray-900/60 px-4 py-3 flex items-center justify-between"
+      >
+        <div>
+          <p class="text-xs text-gray-500">今天的 WARM sessions</p>
+          <p class="text-2xl font-semibold text-gray-900 dark:text-white">
+            {{ todayStats.warmCount }}
+          </p>
+        </div>
+        <span class="text-xl">🟠</span>
+      </div>
+      <div
+        class="rounded-2xl border border-gray-200 dark:border-gray-800/60 bg-white dark:bg-gray-900/60 px-4 py-3 flex flex-col justify-center"
+      >
+        <p class="text-xs text-gray-500 mb-1">今日總閱讀時間</p>
+        <p class="text-lg font-semibold text-gray-900 dark:text-white">
+          {{ todayStats.totalDwellFormatted }}
+        </p>
+      </div>
+    </div>
+
+    <div v-if="isLoading" class="flex items-center justify-center py-12">
+      <svg
+        class="w-6 h-6 animate-spin text-brand-500"
+        fill="none"
+        viewBox="0 0 24 24"
+      >
+        <circle
+          class="opacity-25"
+          cx="12"
+          cy="12"
+          r="10"
+          stroke="currentColor"
+          stroke-width="4"
+        />
+        <path
+          class="opacity-75"
+          fill="currentColor"
+          d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+        />
+      </svg>
+    </div>
+
+    <div v-else-if="sessions.length === 0" class="text-sm text-gray-500">
+      目前尚無任何 session 紀錄。
+    </div>
+
+    <div v-else class="overflow-x-auto bg-white dark:bg-gray-900/40 border border-gray-200 dark:border-gray-800/50 rounded-2xl shadow-sm dark:shadow-none">
+      <!-- TODO: documentName / filters will be added here -->
+      <table class="min-w-full text-left text-sm">
+        <thead class="bg-gray-50 dark:bg-gray-900/60 border-b border-gray-200 dark:border-gray-800/70">
+          <tr>
+            <th class="px-4 py-2 font-medium text-gray-500">Document</th>
+            <th class="px-4 py-2 font-medium text-gray-500">Client</th>
+            <th class="px-4 py-2 font-medium text-gray-500">Intent</th>
+            <th class="px-4 py-2 font-medium text-gray-500">Dwell</th>
+            <th class="px-4 py-2 font-medium text-gray-500">Ended</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            v-for="s in sortedSessions"
+            :key="s.id"
+            class="border-b border-gray-100 dark:border-gray-800/70 hover:bg-gray-50/60 dark:hover:bg-gray-900/60 cursor-pointer"
+            @click="goToDetail(s.id)"
+          >
+            <td class="px-4 py-2 text-gray-800 dark:text-gray-100">
+              <div class="flex flex-col">
+                <span class="font-medium">
+                  {{
+                    documents.find((d) => d.id === s.documentId)?.name ||
+                    s.documentId ||
+                    '—'
+                  }}
+                </span>
+                <span class="text-xs text-gray-500">
+                  {{ s.linkId || 'link?' }}
+                </span>
+              </div>
+            </td>
+            <td class="px-4 py-2 text-gray-800 dark:text-gray-100">
+              {{ s.clientName || '—' }}
+            </td>
+            <td class="px-4 py-2">
+              <span
+                class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full border text-xs font-medium"
+                :class="[
+                  getScoreColor(s.intentScore || 0).bg,
+                  getScoreColor(s.intentScore || 0).text,
+                  getScoreColor(s.intentScore || 0).border,
+                ]"
+              >
+                <span>{{ getScoreLabel(s.intentScore || 0) }}</span>
+                <span>· {{ s.intentScore ?? 0 }}</span>
+              </span>
+            </td>
+            <td class="px-4 py-2 text-gray-800 dark:text-gray-100">
+              {{ formatDwell(s.totalDwellSecs || 0) }}
+            </td>
+            <td class="px-4 py-2 text-gray-500">
+              {{ formatEndedAt(s.endedAt, s.createdAt) }}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    </div>
+  </AppShell>
+</template>
+
+<script setup>
+import { computed } from "vue";
+import { useRouter } from "vue-router";
+import AppShell from "../layouts/AppShell.vue";
+import { useAuth } from "../composables/useAuth.js";
+import { useTrackingSessions } from "../composables/useScores.js";
+import { useDocuments } from "../composables/useDocuments.js";
+
+const router = useRouter();
+const { user } = useAuth();
+const { documents, fetchDocuments } = useDocuments();
+const {
+  sessions,
+  isLoading,
+  fetchSessionsByOwner,
+  getScoreLabel,
+  getScoreColor,
+} = useTrackingSessions();
+
+// 依 ownerId 讀取 documents + sessions
+if (user.value?.uid) {
+  fetchDocuments(user.value.uid);
+  fetchSessionsByOwner(user.value.uid);
+}
+
+const selectedDocumentId = computed({
+  get() {
+    const id = router.currentRoute.value.query.documentId;
+    return id || "all";
+  },
+  set(val) {
+    const query = { ...router.currentRoute.value.query };
+    if (val === "all") delete query.documentId;
+    else query.documentId = val;
+    router.replace({ query });
+  },
+});
+
+const filteredSessions = computed(() => {
+  if (selectedDocumentId.value === "all") return sessions.value;
+  return sessions.value.filter((s) => s.documentId === selectedDocumentId.value);
+});
+
+const todayStats = computed(() => {
+  const now = new Date();
+  const startOfDay = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate(),
+    0,
+    0,
+    0,
+  );
+  const endOfDay = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate(),
+    23,
+    59,
+    59,
+  );
+
+  const todaySessions = filteredSessions.value.filter((s) => {
+    const t = s.endedAt?.toDate?.()
+      ? s.endedAt.toDate()
+      : s.createdAt?.toDate?.()
+        ? s.createdAt.toDate()
+        : null;
+    if (!t) return false;
+    return t >= startOfDay && t <= endOfDay;
+  });
+
+  const hotCount = todaySessions.filter((s) => (s.intentScore || 0) > 80).length;
+  const warmCount = todaySessions.filter(
+    (s) => (s.intentScore || 0) > 50 && (s.intentScore || 0) <= 80,
+  ).length;
+  const totalDwellSecs = todaySessions.reduce(
+    (sum, s) => sum + (s.totalDwellSecs || 0),
+    0,
+  );
+
+  return {
+    hotCount,
+    warmCount,
+    totalDwellSecs,
+    totalDwellFormatted: formatDwell(totalDwellSecs),
+  };
+});
+
+const sortedSessions = computed(() => {
+  return [...filteredSessions.value].sort((a, b) => {
+    const aTime = a.endedAt?.toDate?.()
+      ? a.endedAt.toDate()
+      : a.createdAt?.toDate?.()
+        ? a.createdAt.toDate()
+        : new Date(0);
+    const bTime = b.endedAt?.toDate?.()
+      ? b.endedAt.toDate()
+      : b.createdAt?.toDate?.()
+        ? b.createdAt.toDate()
+        : new Date(0);
+    return bTime - aTime;
+  });
+});
+
+const goToDetail = (id) => {
+  if (!id) return;
+  router.push(`/dashboard/sessions/${id}`);
+};
+
+const formatDwell = (totalSecs) => {
+  if (!totalSecs || totalSecs <= 0) return "0s";
+  if (totalSecs < 60) return `${totalSecs}s`;
+  if (totalSecs < 3600)
+    return `${Math.floor(totalSecs / 60)}m ${totalSecs % 60}s`;
+  const hrs = Math.floor(totalSecs / 3600);
+  const mins = Math.floor((totalSecs % 3600) / 60);
+  return `${hrs}h ${mins}m`;
+};
+
+const formatEndedAt = (endedAt, createdAt) => {
+  const ts = endedAt?.toDate?.()
+    ? endedAt.toDate()
+    : createdAt?.toDate?.()
+      ? createdAt.toDate()
+      : null;
+  if (!ts) return "—";
+  return ts.toLocaleString("zh-TW", {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+};
+</script>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -5,6 +5,8 @@ import LoginPage from "../pages/LoginPage.vue";
 import DashboardPage from "../pages/DashboardPage.vue";
 import DocumentPage from "../pages/DocumentPage.vue";
 import ClientsPage from "../pages/ClientsPage.vue";
+import SessionsPage from "../pages/SessionsPage.vue";
+import SessionDetailPage from "../pages/SessionDetailPage.vue";
 
 const routes = [
   {
@@ -33,6 +35,18 @@ const routes = [
     path: "/dashboard/clients",
     name: "Clients",
     component: ClientsPage,
+    meta: { requiresAuth: true },
+  },
+  {
+    path: "/dashboard/sessions",
+    name: "Sessions",
+    component: SessionsPage,
+    meta: { requiresAuth: true },
+  },
+  {
+    path: "/dashboard/sessions/:id",
+    name: "SessionDetail",
+    component: SessionDetailPage,
     meta: { requiresAuth: true },
   },
 ];


### PR DESCRIPTION
This PR introduces the first cut of the **reading sessions analytics** in Qulox Dashboard.

### What's included

1. **AppShell layout**
   - New `src/layouts/AppShell.vue` with shared sidebar (文件管理 / 客戶管理 / 閱讀紀錄).
   - Used by Sessions list & Session detail pages so they share the same dashboard chrome.

2. **Sessions list page (`/dashboard/sessions`)**
   - New `SessionsPage.vue` under the AppShell layout.
   - Shows a summary panel for **today's HOT/WARM sessions** and total dwell time.
   - Main table lists recent sessions for the current owner:
     - Document name (from `documents` collection) + linkId
     - Client name
     - Per-session `intentScore` + label (uses `useTrackingSessions` helpers)
     - Total dwell time
     - End time
   - Document filter:
     - Dropdown to filter sessions by `documentId` (or all documents)
     - Filter state is reflected in `?documentId=` query param for shareability.

3. **Session detail page (`/dashboard/sessions/:id`)**
   - New `SessionDetailPage.vue` under AppShell.
   - Overview card with documentId, linkId, clientName, intentScore + label, total dwell time, and time range.
   - Per-page dwell chart:
     - Uses `pageStats.totalDwellMs` to compute per-page dwell seconds.
     - Normalizes bar width by max dwell time.
   - "Key Behaviors" panel:
     - Summarizes presence of `print_intent`, `text_copy`, `text_selection`, `link_click`, and `zoom_scrutinize`.
     - Shows which pages had copy/selection/link-click events.

### Routing & nav

- Updated `src/router/index.js` with routes for:
  - `/dashboard/sessions` (Sessions)
  - `/dashboard/sessions/:id` (SessionDetail)
- Updated sidebar in `DashboardPage.vue` to add the **閱讀紀錄** entry and keep naming in Chinese.

This should complete the MVP Dashboard milestones for sessions listing and deep dive views, wired up to the existing `tracking_sessions` payload coming from the Qulox viewer.
