### PR TITLE
fix: 確保閱讀紀錄在所有頁面均顯示於 Navbar

### DIFF
--- a/src/pages/ClientsPage.vue
+++ b/src/pages/ClientsPage.vue
@@ -85,6 +85,30 @@
           </svg>
           客戶管理
         </router-link>
+        <router-link
+          to="/dashboard/sessions"
+          class="flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium transition-all duration-150"
+          :class="
+            $route.name === 'Sessions' || $route.name === 'SessionDetail'
+              ? 'bg-brand-500/10 text-brand-600 dark:text-brand-400'
+              : 'text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-gray-800/50'
+          "
+        >
+          <svg
+            class="w-5 h-5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            stroke-width="1.5"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M3.75 4.5h16.5M3.75 9.75h16.5m-16.5 5.25h10.5"
+            />
+          </svg>
+          閱讀紀錄
+        </router-link>
       </nav>
       <div class="p-3 border-t border-gray-100 dark:border-gray-800/50">
         <div class="flex items-center gap-3 px-3 py-2">

--- a/src/pages/DocumentPage.vue
+++ b/src/pages/DocumentPage.vue
@@ -75,6 +75,30 @@
           </svg>
           客戶管理
         </router-link>
+        <router-link
+          to="/dashboard/sessions"
+          class="flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium transition-all duration-150"
+          :class="
+            $route.name === 'Sessions' || $route.name === 'SessionDetail'
+              ? 'bg-brand-500/10 text-brand-600 dark:text-brand-400'
+              : 'text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-gray-800/50'
+          "
+        >
+          <svg
+            class="w-5 h-5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            stroke-width="1.5"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M3.75 4.5h16.5M3.75 9.75h16.5m-16.5 5.25h10.5"
+            />
+          </svg>
+          閱讀紀錄
+        </router-link>
       </nav>
       <div class="p-3 border-t border-gray-100 dark:border-gray-800/50">
         <div class="flex items-center gap-3 px-3 py-2">


### PR DESCRIPTION
## Summary

修正「閱讀紀錄」在文件詳細頁面及客戶管理頁面從 Navbar 消失的問題。

根本原因：`DocumentPage.vue` 和 `ClientsPage.vue` 的 sidebar `<nav>` 中漏掉了「閱讀紀錄」的 `<router-link>`。

## Changes

- `DocumentPage.vue`：加入「閱讀紀錄」router-link
- `ClientsPage.vue`：加入「閱讀紀錄」router-link
- 兩處均加入 active 狀態 class binding

Fixes #10