### PR TITLE
fix: 閱讀細節頁面顯示文件名稱而非文件 ID

### DIFF
--- a/src/pages/SessionDetailPage.vue
+++ b/src/pages/SessionDetailPage.vue
@@ -62,7 +62,7 @@
           <div class="space-y-1">
             <p class="text-xs text-gray-500">Document</p>
             <p class="text-sm font-medium text-gray-900 dark:text-white">
-              {{ session.documentId || '—' }}
+              {{ documentName || session.documentId || '—' }}
             </p>
             <p class="text-xs text-gray-500">
               Link: {{ session.linkId || '—' }}
@@ -226,6 +226,7 @@ const route = useRoute();
 const router = useRouter();
 const session = ref(null);
 const isLoading = ref(true);
+const documentName = ref(null);
 
 const { getScoreLabel, getScoreColor } = useTrackingSessions();
 
@@ -243,6 +244,17 @@ onMounted(async () => {
     const snap = await getDoc(doc(db, "tracking_sessions", id));
     if (snap.exists()) {
       session.value = { id: snap.id, ...snap.data() };
+      // Fetch document name
+      if (session.value.documentId) {
+        try {
+          const docSnap = await getDoc(doc(db, "documents", session.value.documentId));
+          if (docSnap.exists()) {
+            documentName.value = docSnap.data().name || docSnap.data().fileName || null;
+          }
+        } catch (_) {
+          // Silently fall back to ID if fetch fails
+        }
+      }
     }
   } catch (e) {
     console.error("Failed to load session", e);


### PR DESCRIPTION
## Summary

修正「閱讀細節」頁面中 Document 欄位顯示 Firestore ID（如 `9QZZunxG6uW3Z0O34Uu6`）的問題，改為顯示對應的文件名稱。

## Changes

- `SessionDetailPage.vue`：在 `onMounted` 載入 session 後，額外查詢 `documents` collection 取得文件名稱（`name` 或 `fileName`）
- Template 改為優先顯示 `documentName`，查詢失敗時 fallback 至 documentId

## Testing

- 進入閱讀紀錄 → 點進 session 詳細頁，Document 欄位顯示文件名稱 ✅
- 若文件已刪除或查詢失敗，仍顯示 documentId（不會 crash）✅

Fixes #15